### PR TITLE
[FIX] Fixed wrong url parts usage when updating website menu urls whi…

### DIFF
--- a/website_seo/models/ir_ui_view.py
+++ b/website_seo/models/ir_ui_view.py
@@ -149,7 +149,7 @@ class View(models.Model):
 
     @api.model
     def find_by_seo_path(self, path):
-        url_parts = path.split('/')
+        url_parts = [u for u in path.split('/') if u != '']
         views = self.search([('seo_url', 'in', url_parts)],
                             order='seo_url_level ASC')
         if len(url_parts) == len(views):


### PR DESCRIPTION
…ch could lead to non updatable website menu urls.

The problem with splitting a string like **/seo_url** by split('/') will end in a list with two elements **['', 'seo_url']**. That causes the problem that the condition in website_seo/models/ir_ui_view.py (line 155) always fails, the length of the result views is 1 but the length of the url parts is 2.
